### PR TITLE
Game state renaming -  1.0.6

### DIFF
--- a/src/main/java/com/progzesp/stalking/domain/GameEto.java
+++ b/src/main/java/com/progzesp/stalking/domain/GameEto.java
@@ -91,12 +91,12 @@ public class GameEto extends com.progzesp.stalking.domain.AbstractEto {
     }
 
     public GameEto() {
-        this.setState(GameState.SETTING_UP);
+        this.setState(GameState.CREATED);
     }
 
     public GameEto(Long gameMasterId) {
         this.setGameMasterId(gameMasterId);
         this.setStartDate(new Date());
-        this.setState(GameState.SETTING_UP);
+        this.setState(GameState.CREATED);
     }
 }

--- a/src/main/java/com/progzesp/stalking/persistance/entity/GameState.java
+++ b/src/main/java/com/progzesp/stalking/persistance/entity/GameState.java
@@ -2,9 +2,9 @@ package com.progzesp.stalking.persistance.entity;
 
 public enum GameState {
 
-    SETTING_UP,
-    WAITING_FOR_PLAYERS,
-    ONGOING,
-    ENDED
+    CREATED,
+    PENDING,
+    STARTED,
+    FINISHED
 
 }

--- a/src/main/java/com/progzesp/stalking/service/impl/GameServiceImpl.java
+++ b/src/main/java/com/progzesp/stalking/service/impl/GameServiceImpl.java
@@ -95,15 +95,15 @@ public class GameServiceImpl implements GameService {
 
     @Override
     public GameState openWaitingRoom(Long id) {
-        return advanceGame(id, GameState.WAITING_FOR_PLAYERS, List.of(GameState.SETTING_UP));
+        return advanceGame(id, GameState.PENDING, List.of(GameState.CREATED));
     }
     @Override
     public GameState startGameplay(Long id) {
-        return advanceGame(id, GameState.ONGOING, List.of(GameState.WAITING_FOR_PLAYERS));
+        return advanceGame(id, GameState.STARTED, List.of(GameState.PENDING));
     }
     @Override
     public GameState endGameplay(Long id) {
-        return advanceGame(id, GameState.ENDED, List.of(GameState.ONGOING));
+        return advanceGame(id, GameState.FINISHED, List.of(GameState.STARTED));
     }
 
     @Override


### PR DESCRIPTION
Zmieniono nazwy stanów gry, aby zgadzały się z dokumentacją w wersji 1.0.6:
CREATED -> PENDING -> STARTED -> FINISHED